### PR TITLE
Add global 401 error handling and fetchWithAuth utility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "react-hook-form": "^7.53.2",
         "react-redux": "^9.2.0",
         "react-router-dom": "^6.28.0",
+        "react-toastify": "^11.0.5",
         "redux-persist": "^6.0.0",
         "styled-components": "^6.1.13",
         "tailwind-merge": "^3.0.2",
@@ -118,6 +119,7 @@
       "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -1221,6 +1223,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -1232,6 +1235,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -3264,6 +3268,7 @@
       "resolved": "https://registry.npmjs.org/@svgdotjs/svg.js/-/svg.js-3.2.4.tgz",
       "integrity": "sha512-BjJ/7vWNowlX3Z8O4ywT58DqbNRyYlkk6Yz/D13aB7hGmfQTvGX4Tkgtm/ApYlu9M7lCQi15xUEidqMUmdMYwg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Fuzzyma"
@@ -3287,6 +3292,7 @@
       "resolved": "https://registry.npmjs.org/@svgdotjs/svg.select.js/-/svg.select.js-4.0.2.tgz",
       "integrity": "sha512-5gWdrvoQX3keo03SCmgaBbD+kFftq0F/f2bzCbNnpkkvW6tk4rl4MakORzFuNjvXPWwB4az9GwuvVxQVnjaK2g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14.18"
       },
@@ -3390,6 +3396,7 @@
       "integrity": "sha512-ii/gswMmOievxAJed4PAHT949bpYjPKXvXo1v6cRB/kqc2ZR4n+SgyCyvyc5Fec5ez8VnUumI1Vk7j6fRyRogg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3401,6 +3408,7 @@
       "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -3465,6 +3473,7 @@
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3922,6 +3931,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -4772,6 +4782,7 @@
       "integrity": "sha512-whp8mSQI4C8VXd+fLgSM0lh3UlmcFtVwUQjyKCFfsp+2ItAIYhlq/hqGahGqHE6cv9unM41VlqKk2VtKYR2TaA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6125,6 +6136,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
       "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6865,6 +6877,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -7084,6 +7097,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7112,6 +7126,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7146,6 +7161,7 @@
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -7275,6 +7291,19 @@
         }
       }
     },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -7311,7 +7340,8 @@
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "peer": true
     },
     "node_modules/redux-persist": {
       "version": "6.0.0",
@@ -7446,6 +7476,7 @@
       "integrity": "sha512-G9GOrmgWHBma4YfCcX8PjH0qhXSdH8B4HDE2o4/jaxj93S4DPCIDoLcXz99eWMji4hB29UFCEd7B2gwGJDR9cQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.6"
       },
@@ -8106,6 +8137,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.16.tgz",
       "integrity": "sha512-TI4Cyx7gDiZ6r44ewaJmt0o6BrMCT5aK5e0rmJ/G9Xq3w7CX/5VXl/zIPEJZFUK5VEqwByyhqNPycPlvcK4ZNw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -8492,6 +8524,7 @@
       "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-hook-form": "^7.53.2",
     "react-redux": "^9.2.0",
     "react-router-dom": "^6.28.0",
+    "react-toastify": "^11.0.5",
     "redux-persist": "^6.0.0",
     "styled-components": "^6.1.13",
     "tailwind-merge": "^3.0.2",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,8 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { lazy, Suspense, useEffect } from "react";
+import { ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
+import { fetchWithAuth } from "./utils/fetchWithAuth";
 import AgentSystemsTraining from "./pages/agentPages/AgentSystemsTraining";
 import InteractionGuidePage from "./pages/IG/InteractionGuidePage";
 import AddUserSupervisor from "./pages/supervisorPages/AddUserSupervisor";
@@ -148,7 +151,7 @@ function App() {
 
         if (ip !== ipAddress) {
                   
-          const res = await fetch(`${AUTH_URL}/guide_auth/whitelist_ip`, {
+          const res = await fetchWithAuth(`${AUTH_URL}/guide_auth/whitelist_ip`, {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
@@ -516,6 +519,7 @@ function App() {
           </Routes>
         </Suspense>
       </BrowserRouter>
+      <ToastContainer />
     </>
   );
 }

--- a/src/config/https.js
+++ b/src/config/https.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { toast } from "react-toastify";
 
 const base_url = "https://auth.itsbuzzmarketing.com";
 // const auth_url = "";
@@ -42,11 +43,26 @@ const responseHandler = async (response) => {
 
 const errorHandler = (error) => {
   const { response } = error;
-  // console.log(response, "error handler");
+  
+  // Handle 401 Unauthorized errors globally
+  if (response && response.status === 401) {
+    // Show toast message
+    toast.error("Your session has expired. Please log out and log in again to reauthenticate.", {
+      position: "top-right",
+      className: "toastPosition",
+      autoClose: 5000,
+    });
+    
+    // Return a rejected promise to prevent further processing
+    return Promise.reject(error);
+  }
 
+  // For other errors, return response as before
   if (response && response?.status) {
     return response;
   }
+  
+  return Promise.reject(error);
 };
 
 //inceptors

--- a/src/features/hooks/useFetch.js
+++ b/src/features/hooks/useFetch.js
@@ -46,12 +46,11 @@ const useFetch = () => {
       }
     } catch (e) {
       setLoading(false);
-      if (e.status === 401) {
-        dispatch(logout());
-      } else if (e.status !== 404) {
+      // 401 is now handled globally by axios interceptor
+      if (e.status !== 401 && e.status !== 404) {
         setError(e.data?.message);
         //notify("error", e.data?.message);
-      } else if (e.status !== 401) {
+      } else if (e.status === 404) {
         setError(e.statusText);
         //notify("error", e.statusText);
       }
@@ -94,13 +93,11 @@ const useFetch = () => {
       }
     } catch (e) {
       setLoading(false);
-      if (e.status === 401) {
-        dispatch(logout());
-      }
-      if (e.status !== 404) {
+      // 401 is now handled globally by axios interceptor
+      if (e.status !== 401 && e.status !== 404) {
         setError(e.data?.message);
         //notify("error", e.data?.message);
-      } else {
+      } else if (e.status === 404) {
         setError(e.statusText);
         //notify("error", e.statusText);
       }
@@ -143,13 +140,11 @@ const useFetch = () => {
     } catch (e) {
       setLoading(false);
       setSuccess(false);
-      if (e.status === 401) {
-        dispatch(logout());
-      }
-      if (e.status !== 404) {
+      // 401 is now handled globally by axios interceptor
+      if (e.status !== 401 && e.status !== 404) {
         setError(e.data?.message);
         //notify("error", e.data?.message);
-      } else {
+      } else if (e.status === 404) {
         setError(e.statusText);
         //notify("error", e.statusText);
       }
@@ -221,13 +216,11 @@ const useFetch = () => {
     } catch (e) {
       setLoading(false);
       setSuccess(false);
-      if (e.status === 401) {
-        dispatch(logout());
-      }
-      if (e.status !== 404) {
+      // 401 is now handled globally by axios interceptor
+      if (e.status !== 401 && e.status !== 404) {
         setError(e.data?.message);
         //notify("error", e.data?.message);
-      } else {
+      } else if (e.status === 404) {
         setError(e.statusText);
         //notify("error", e.statusText);
       }
@@ -257,13 +250,11 @@ const useFetch = () => {
     } catch (e) {
       setLoading(false);
       setSuccess(false);
-      if (e.status === 401) {
-        dispatch(logout());
-      }
-      setError(e.data?.message);
-      if (e.status !== 404) {
+      // 401 is now handled globally by axios interceptor
+      if (e.status !== 401 && e.status !== 404) {
+        setError(e.data?.message);
         //notify("error", e.data?.message);
-      } else {
+      } else if (e.status === 404) {
         setError(e.statusText);
         //notify("error", e.statusText);
       }
@@ -291,13 +282,11 @@ const useFetch = () => {
       }
     } catch (e) {
       setLoading(false);
-      if (e.status === 401) {
-        dispatch(logout());
-      }
-      if (e.status !== 404) {
+      // 401 is now handled globally by axios interceptor
+      if (e.status !== 401 && e.status !== 404) {
         setError(e.data?.message);
         //notify("error", e.data?.message);
-      } else {
+      } else if (e.status === 404) {
         setError(e.statusText);
         //notify("error", e.statusText);
       }

--- a/src/features/hooks/useGetAPI.js
+++ b/src/features/hooks/useGetAPI.js
@@ -46,9 +46,7 @@ const useGetAPI = () => {
       }
     } catch (e) {
       setLoading(false);
-      if (e.message=="Unauthorized") {
-        dispatch(logout())
-      }
+      // 401 is now handled globally by axios interceptor
       setError(e.message);
       //temporary commented error log
       // console.log(e.message,"checking  message------>");

--- a/src/pages/adminPages/contactsDashboard/contacts-dashboard.tsx
+++ b/src/pages/adminPages/contactsDashboard/contacts-dashboard.tsx
@@ -10,6 +10,7 @@ import { Separator } from "./ui/separator"
 import ContactsTable from "./contacts-table"
 import React from "react"
 import { useSelector } from "react-redux"
+import { fetchWithAuth } from "../../../utils/fetchWithAuth"
 
 // Define the Contact type
 interface Contact {
@@ -23,7 +24,7 @@ interface Contact {
 }
 
 // const BACKEND_URL = "http://0.0.0.0:3173"
-const BACKEND_URL = "https://endpoint.itsbuzzmarketing.com"
+const BACKEND_URL = "https://app.itsbuzzmarketing.com"
 
 
 // fetch fields from the server
@@ -33,7 +34,7 @@ const fetchFields = async ( token: string ) => {
   const headers = new Headers()
   headers.append("Authorization", `Bearer ${token}`)
 
-  const response = await fetch(`${BACKEND_URL}/guides/get_fields`, {
+  const response = await fetchWithAuth(`${BACKEND_URL}/guides/get_fields`, {
     method: "GET",
     headers: headers,          
   })
@@ -69,7 +70,7 @@ const fetchContacts = async ( fields : string[], filters : {}, token: string  ) 
 
   headers.append("Content-Type", "application/json")
 
-  const response = await fetch(`${BACKEND_URL}/guides/get_contacts`, {
+  const response = await fetchWithAuth(`${BACKEND_URL}/guides/get_contacts`, {
     method: "POST",
     headers: headers,
     body: body
@@ -188,7 +189,7 @@ export default function ContactsDashboard() {
           filters: {},
         })
 
-        const response = await fetch(`${BACKEND_URL}/guides/get_contact_csv`, {
+        const response = await fetchWithAuth(`${BACKEND_URL}/guides/get_contact_csv`, {
           method: "POST",
           headers: headers,
           body: body,

--- a/src/pages/agentPages/dnc-form.tsx
+++ b/src/pages/agentPages/dnc-form.tsx
@@ -19,8 +19,9 @@ import {
 import Navbar from "../../components/navigationBar/navbar"
 import { useSelector } from "react-redux"
 import { useNavigate } from "react-router-dom"
+import { fetchWithAuth } from "../../utils/fetchWithAuth"
 
-const UPLOAD_URL = "https://endpoint.itsbuzzmarketing.com";
+const UPLOAD_URL = "https://app.itsbuzzmarketing.com";
 // const UPLOAD_URL = "http://127.0.0.1:3173";
 // const UPLOAD_URL = "https://combined-service.r9tsjnbaapfz8.us-east-1.cs.amazonlightsail.com/"
 
@@ -81,7 +82,7 @@ const DNCForm = () => {
     setIsSubmitting(true)
 
     try {
-      const response = await fetch(`${UPLOAD_URL}/guides/dnc-registry-insert?phone_number=${cleanedNumber}`, {
+      const response = await fetchWithAuth(`${UPLOAD_URL}/guides/dnc-registry-insert?phone_number=${cleanedNumber}`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/src/pages/dataVendorPages/LeadFormPage.tsx
+++ b/src/pages/dataVendorPages/LeadFormPage.tsx
@@ -13,6 +13,7 @@ import { Alert, AlertDescription } from "../../components/ui/alert"
 import { useSelector } from "react-redux"
 import { useNavigate } from "react-router-dom"
 import Navbar from "../../components/navigationBar/navbar"
+import { fetchWithAuth } from "../../utils/fetchWithAuth"
 
 const DEFAULT_EMAILS = [
   "glenfiddich.apayart@itsbuzzmarketing.com", 
@@ -22,7 +23,7 @@ const DEFAULT_EMAILS = [
   "kenneth.candor@itsbuzzmarketing.com"
 ]
 
-const UPLOAD_URL = "https://endpoint.itsbuzzmarketing.com";
+const UPLOAD_URL = "https://app.itsbuzzmarketing.com";
 // const UPLOAD_URL = "http://127.0.0.1:3173";
 // const UPLOAD_URL = "https://combined-service.r9tsjnbaapfz8.us-east-1.cs.amazonlightsail.com/"
 
@@ -165,7 +166,7 @@ const LeadFormPage = () => {
 
     setIsUploading(true)
 
-    const response = await fetch(`${UPLOAD_URL}/guides/uploadLeadForm`, {
+    const response = await fetchWithAuth(`${UPLOAD_URL}/guides/uploadLeadForm`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${token}`,

--- a/src/pages/dataVendorPages/LeadUploads.tsx
+++ b/src/pages/dataVendorPages/LeadUploads.tsx
@@ -27,8 +27,9 @@ import {
 } from "lucide-react";
 import { useSelector } from "react-redux";
 import Navbar from "../../components/navigationBar/navbar";
+import { fetchWithAuth } from "../../utils/fetchWithAuth";
 
-const UPLOAD_URL = "https://endpoint.itsbuzzmarketing.com";
+const UPLOAD_URL = "https://app.itsbuzzmarketing.com";
 // const UPLOAD_URL = "http://127.0.0.1:3173";
 
 const LeadUploads = () => {
@@ -65,7 +66,7 @@ const LeadUploads = () => {
   const fetchUploadData = async () => {
     setIsLoading(true);
     try {
-      const response = await fetch(`${UPLOAD_URL}/guides/get-lead-form-history`, {
+      const response = await fetchWithAuth(`${UPLOAD_URL}/guides/get-lead-form-history`, {
         headers: {
           Authorization: `Bearer ${token}`,
         },

--- a/src/pages/dataVendorPages/externalVendor.tsx
+++ b/src/pages/dataVendorPages/externalVendor.tsx
@@ -10,6 +10,7 @@ import { Alert, AlertDescription } from "../../components/ui/alert"
 import { useSelector } from "react-redux"
 import { useNavigate } from "react-router-dom"
 import Navbar from "../../components/navigationBar/navbar"
+import { fetchWithAuth } from "../../utils/fetchWithAuth"
 
 
 const DEFAULT_EMAILS = [
@@ -20,7 +21,7 @@ const DEFAULT_EMAILS = [
   "kenneth.candor@itsbuzzmarketing.com"
 ]
 
-const UPLOAD_URL = "https://endpoint.itsbuzzmarketing.com";
+const UPLOAD_URL = "https://app.itsbuzzmarketing.com";
 
 // const UPLOAD_URL = "http://127.0.0.1:3173";
 // const UPLOAD_URL = "https://combined-service.r9tsjnbaapfz8.us-east-1.cs.amazonlightsail.com/"
@@ -77,7 +78,7 @@ const ExternalVendorForm = () => {
 
     setIsUploading(true)
 
-    const response = await fetch(`${UPLOAD_URL}/guides/vendorLeadForm`, {
+    const response = await fetchWithAuth(`${UPLOAD_URL}/guides/vendorLeadForm`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${token}`,

--- a/src/pages/supervisorPages/BuzzWord.jsx
+++ b/src/pages/supervisorPages/BuzzWord.jsx
@@ -5,6 +5,7 @@ import { useSelector } from "react-redux";
 import TiSolutionsLogoSvg from "../../assets/SVGs/logos/TiSolutionsLogoSvg";
 import ItsBuzzMarketingLogo from "../../assets/SVGs/logos/ItsBuzzMarketingLogo";
 import { BuzzwordIdModel } from "../../components/modals/BuzzwordIdModel";
+import { fetchWithAuth } from "../../utils/fetchWithAuth";
 
 const BuzzWord = () => {
   const {
@@ -15,7 +16,7 @@ const BuzzWord = () => {
 
   const [readOnly, setReadOnly] = useState(false);
   const { token } = useSelector((state) => state.user);
-  const URL = "https://endpoint.itsbuzzmarketing.com";
+  const URL = "https://app.itsbuzzmarketing.com";
   // const URL = "http://localhost:3173";
   const [open, setOpen] = useState(false);
   const [buzzRes, setBuzzRes] = useState(null);
@@ -50,7 +51,7 @@ const BuzzWord = () => {
     return { id: index + 1, name: names[index] };
   });
   const onSubmit = async (data) => {
-    const response = await fetch(`${URL}/buzzword/create_new_buzzword`, {
+    const response = await fetchWithAuth(`${URL}/buzzword/create_new_buzzword`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/src/pages/supervisorPages/CreateTemplatePage.tsx
+++ b/src/pages/supervisorPages/CreateTemplatePage.tsx
@@ -10,6 +10,7 @@ import { CSVMapper } from "../../components/CSVMapper/CSVMapper"
 import { PlusCircle, Upload } from "lucide-react"
 import { set } from "react-hook-form";
 import { useSelector } from "react-redux";
+import { fetchWithAuth } from "../../utils/fetchWithAuth";
 
 
 // Available data types 
@@ -23,7 +24,7 @@ const dataTypes = [
 
 // const UPLOAD_URL = "https://combined-service.r9tsjnbaapfz8.us-east-1.cs.amazonlightsail.com/"
 // const UPLOAD_URL = "http://localhost:3173"
-const UPLOAD_URL = "https://endpoint.itsbuzzmarketing.com/"
+const UPLOAD_URL = "https://app.itsbuzzmarketing.com/"
 
 
 export default function CreateTemplatePage() {
@@ -46,7 +47,7 @@ export default function CreateTemplatePage() {
   useEffect(() => {
 
     async function fetchFields(){
-      const response = await fetch(
+      const response = await fetchWithAuth(
         `${UPLOAD_URL}/guides/get_fields`,
         {
           method: "GET",
@@ -89,7 +90,7 @@ export default function CreateTemplatePage() {
     
     async function getSourcesTemplates(){
 
-      const response = await fetch(`${UPLOAD_URL}/guides/get_all_sources`,
+      const response = await fetchWithAuth(`${UPLOAD_URL}/guides/get_all_sources`,
         {
           method: "GET",
           headers: {            
@@ -199,7 +200,7 @@ export default function CreateTemplatePage() {
     }
 
     // submit 
-    fetch(`${UPLOAD_URL}/guides/create_template`, {
+    fetchWithAuth(`${UPLOAD_URL}/guides/create_template`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${token}`,

--- a/src/pages/supervisorPages/UploadDataPage.jsx
+++ b/src/pages/supervisorPages/UploadDataPage.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { set, useForm } from "react-hook-form";
 import useFetch from "./../../features/hooks/useFetch";
 import { useSelector } from "react-redux";
+import { fetchWithAuth } from "../../utils/fetchWithAuth";
 const UploadDataPage = () => {
   const { token } = useSelector((state) => state.user);
   const [showPassword, setShowPassword] = useState(false);
@@ -11,7 +12,7 @@ const UploadDataPage = () => {
   const [uploadData, setUploadData] = useState([]);
   const [wait, setWait] = useState(false);
 
-  const UPLOAD_URL = "https://endpoint.itsbuzzmarketing.com";
+  const UPLOAD_URL = "https://app.itsbuzzmarketing.com";
   // const UPLOAD_URL = "http://127.0.0.1:3173";
   // const UPLOAD_URL = "https://combined-service.r9tsjnbaapfz8.us-east-1.cs.amazonlightsail.com/"
 
@@ -27,7 +28,7 @@ const UploadDataPage = () => {
       const url = `${UPLOAD_URL}/guides/get_templates`;
 
 
-      const response = await fetch(url, {
+      const response = await fetchWithAuth(url, {
         method: "GET",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -57,7 +58,7 @@ const UploadDataPage = () => {
       const url = `${UPLOAD_URL}/guides/get_upload_tasks`;
 
 
-      const response = await fetch(url, {
+      const response = await fetchWithAuth(url, {
         method: "GET",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -101,7 +102,7 @@ const UploadDataPage = () => {
 
             setWait(true);
 
-            const response = await fetch(url, {
+            const response = await fetchWithAuth(url, {
               method: "POST",
               headers: {
                 Authorization: `Bearer ${token}`,

--- a/src/pages/supervisorPages/showUploads.tsx
+++ b/src/pages/supervisorPages/showUploads.tsx
@@ -30,8 +30,9 @@ import {
 } from "lucide-react";
 import { useSelector } from "react-redux";
 import Navbar from "../../components/navigationBar/navbar";
+import { fetchWithAuth } from "../../utils/fetchWithAuth";
 
-const UPLOAD_URL = "https://endpoint.itsbuzzmarketing.com";
+const UPLOAD_URL = "https://app.itsbuzzmarketing.com";
 // const UPLOAD_URL = "http://127.0.0.1:3173";
 // const UPLOAD_URL = "http://54.167.53.149"
 
@@ -570,7 +571,7 @@ const ShowUploads = () => {
     setIsLoading(true);
     try {
       // Replace with actual API endpoint
-      const response = await fetch(`${UPLOAD_URL}/guides/get-upload-history`, {
+      const response = await fetchWithAuth(`${UPLOAD_URL}/guides/get-upload-history`, {
         headers: {
           Authorization: `Bearer ${token}`,
         },

--- a/src/pages/supervisorPages/uploadLeadFile.tsx
+++ b/src/pages/supervisorPages/uploadLeadFile.tsx
@@ -15,6 +15,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } f
 import { useNavigate } from "react-router-dom";
 import Navbar from "../../components/navigationBar/navbar";
 import { autoMapColumns } from "../../utils/columnMapper";
+import { fetchWithAuth } from "../../utils/fetchWithAuth";
 
 // Predefined column mappings with required fields 
 // Received from @Jessie 20/06/2025, could be automated
@@ -250,7 +251,7 @@ const UploadLeadFile = () => {
         formData.append("download_file", JSON.stringify(downloadFile));
       }
 
-      const response = await fetch(`${UPLOAD_URL}/guides/check-file-validity`, {
+      const response = await fetchWithAuth(`${UPLOAD_URL}/guides/check-file-validity`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -296,7 +297,7 @@ const UploadLeadFile = () => {
         formData.append("download_file", JSON.stringify(downloadFile));
       }
 
-      const response = await fetch(`${UPLOAD_URL}/guides/check-file-validity`, {
+      const response = await fetchWithAuth(`${UPLOAD_URL}/guides/check-file-validity`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -339,7 +340,7 @@ const UploadLeadFile = () => {
         duplicateFormData.append("vendor_lead_code", vendorLeadCode || "");
         duplicateFormData.append("dup_check_scope", duplicateCheckScope);
         
-        const duplicateResponse = await fetch(`${UPLOAD_URL}/guides/check-duplicates`, {
+        const duplicateResponse = await fetchWithAuth(`${UPLOAD_URL}/guides/check-duplicates`, {
           method: "POST",
           headers: {
             Authorization: `Bearer ${token}`,
@@ -442,7 +443,7 @@ const UploadLeadFile = () => {
 
       function fetchWrapper(url, options, timeout) {
         return new Promise((resolve, reject) => {
-          fetch(url, options).then(resolve, reject);
+          fetchWithAuth(url, options).then(resolve, reject);
     
           if (timeout) {
             const e = new Error("Connection timed out");
@@ -631,7 +632,7 @@ const UploadLeadFile = () => {
         formData.append("duplicate_file", duplicateFile);
       }
 
-      const response = await fetch(`${UPLOAD_URL}/guides/upload`, {
+      const response = await fetchWithAuth(`${UPLOAD_URL}/guides/upload`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${token}`,

--- a/src/pages/traineePages/BuzzWordTrainee.jsx
+++ b/src/pages/traineePages/BuzzWordTrainee.jsx
@@ -5,6 +5,7 @@ import TiSolutionsLogoSvg from "../../assets/SVGs/logos/TiSolutionsLogoSvg";
 import ItsBuzzMarketingLogo from "../../assets/SVGs/logos/ItsBuzzMarketingLogo";
 import { useParams } from "react-router-dom";
 import { useSelector } from "react-redux";
+import { fetchWithAuth } from "../../utils/fetchWithAuth";
 
 const BuzzWordTrainee = () => {
   // Grid items with id and name
@@ -48,7 +49,7 @@ const BuzzWordTrainee = () => {
 
 
   // const URL = "https://endpoint.itsbuzzmarketing.com";
-  const URL = "https://endpoint.itsbuzzmarketing.com";
+  const URL = "https://app.itsbuzzmarketing.com";
   const {
     register,
     handleSubmit,
@@ -65,7 +66,7 @@ const BuzzWordTrainee = () => {
     });
   };
   const submitButtonClick = useCallback(async () => {
-    const response = await fetch(`${URL}/buzzword/submit_buzzword`, {
+    const response = await fetchWithAuth(`${URL}/buzzword/submit_buzzword`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -120,7 +121,7 @@ const BuzzWordTrainee = () => {
     const fetchGridItems = async () => {
 
       
-      const response = await fetch(`${URL}/buzzword/get_buzzword/${buzz_id}`, {
+      const response = await fetchWithAuth(`${URL}/buzzword/get_buzzword/${buzz_id}`, {
         method: "GET",
         headers: {
           "Content-Type": "application/json",

--- a/src/pages/traineePages/HR/Documentation/TraineeForm1099.jsx
+++ b/src/pages/traineePages/HR/Documentation/TraineeForm1099.jsx
@@ -391,7 +391,7 @@ const TraineeForm1099 = () => {
       };
 
       fetch(
-        "https://endpoint.itsbuzzmarketing.com/user/upload_document",
+        "https://app.itsbuzzmarketing.com/user/upload_document",
         requestOptions
       )
         .then((response) => response.text())

--- a/src/pages/traineePages/HR/Documentation/TraineeFormw9.jsx
+++ b/src/pages/traineePages/HR/Documentation/TraineeFormw9.jsx
@@ -281,7 +281,7 @@ const TraineeFormW9 = () => {
         };
 
         fetch(
-          "https://endpoint.itsbuzzmarketing.com/user/upload_document",
+          "https://app.itsbuzzmarketing.com/user/upload_document",
           requestOptions
         )
           .then((response) => response.text())

--- a/src/utils/api.jsx
+++ b/src/utils/api.jsx
@@ -1,3 +1,5 @@
+import { fetchWithAuth } from "./fetchWithAuth";
+
 const AUTH_URL="https://end-point.75e8s1syn0vdw.us-east-1.cs.amazonlightsail.com/guide_auth/"
 
 const API = {
@@ -15,7 +17,7 @@ const API = {
     },
     getRole : async ( token ) => {
         // Use this function to get the role of a user when needed
-        const response = await fetch(AUTH_URL+'getRole', {
+        const response = await fetchWithAuth(AUTH_URL+'getRole', {
             method: 'GET',
             headers: {
                 'Content-Type': 'application/json',

--- a/src/utils/fetchWithAuth.js
+++ b/src/utils/fetchWithAuth.js
@@ -1,0 +1,36 @@
+import { toast } from "react-toastify";
+
+/**
+ * Wrapper around fetch() that handles 401 errors globally
+ * Shows a reauthentication message and logs out the user
+ * 
+ * @param {string} url - The URL to fetch
+ * @param {RequestInit} options - Fetch options (headers, method, body, etc.)
+ * @returns {Promise<Response>} - The fetch response
+ */
+export const fetchWithAuth = async (url, options = {}) => {
+  try {
+    const response = await fetch(url, options);
+    
+    // Check for 401 Unauthorized
+    if (response.status === 401) {
+      // Show toast message
+      toast.error("Your session has expired. Please log out and log in again to reauthenticate.", {
+        position: "top-right",
+        className: "toastPosition",
+        autoClose: 5000,
+      });
+      
+      return response; // Return response so caller can handle it
+    }
+    
+    return response;
+  } catch (error) {
+    // Re-throw network errors
+    throw error;
+  }
+};
+
+
+
+


### PR DESCRIPTION
Introduces a fetchWithAuth utility to handle 401 Unauthorized errors globally and display a toast notification. Refactors all API calls to use fetchWithAuth, updates endpoint URLs to 'https://app.itsbuzzmarketing.com', and integrates react-toastify for user session feedback. Removes redundant local 401 handling from hooks and components.