### PR TITLE
Show backend error messages for 401 responses

### DIFF
--- a/src/config/https.js
+++ b/src/config/https.js
@@ -42,16 +42,28 @@ const responseHandler = async (response) => {
 };
 
 const errorHandler = (error) => {
-  const { response } = error;
+  const { response, config } = error;
   
   // Handle 401 Unauthorized errors globally
   if (response && response.status === 401) {
-    // Show toast message
-    toast.error("Your session has expired. Please log out and log in again to reauthenticate.", {
-      position: "top-right",
-      className: "toastPosition",
-      autoClose: 5000,
-    });
+    // Try to get the error message from the backend response
+    const errorMessage = response.data?.message || response.data?.error || null;
+    
+    if (errorMessage) {
+      // Show the specific error message from backend
+      toast.error(errorMessage, {
+        position: "top-right",
+        className: "toastPosition",
+        autoClose: 5000,
+      });
+    } else {
+      // Fallback to generic session expired message if no specific message
+      toast.error("Your session has expired. Please log out and log in again to reauthenticate.", {
+        position: "top-right",
+        className: "toastPosition",
+        autoClose: 5000,
+      });
+    }
     
     // Return a rejected promise to prevent further processing
     return Promise.reject(error);

--- a/src/utils/fetchWithAuth.js
+++ b/src/utils/fetchWithAuth.js
@@ -14,12 +14,32 @@ export const fetchWithAuth = async (url, options = {}) => {
     
     // Check for 401 Unauthorized
     if (response.status === 401) {
-      // Show toast message
-      toast.error("Your session has expired. Please log out and log in again to reauthenticate.", {
-        position: "top-right",
-        className: "toastPosition",
-        autoClose: 5000,
-      });
+      // Try to get the error message from the backend response
+      let errorMessage = null;
+      try {
+        // Clone the response so we can read it without consuming it
+        const clonedResponse = response.clone();
+        const data = await clonedResponse.json();
+        errorMessage = data?.message || data?.error || null;
+      } catch (e) {
+        // If response is not JSON or can't be parsed, use fallback message
+      }
+      
+      if (errorMessage) {
+        // Show the specific error message from backend
+        toast.error(errorMessage, {
+          position: "top-right",
+          className: "toastPosition",
+          autoClose: 5000,
+        });
+      } else {
+        // Fallback to generic session expired message if no specific message
+        toast.error("Your session has expired. Please log out and log in again to reauthenticate.", {
+          position: "top-right",
+          className: "toastPosition",
+          autoClose: 5000,
+        });
+      }
       
       return response; // Return response so caller can handle it
     }


### PR DESCRIPTION
Updated global 401 Unauthorized error handling in https.js and fetchWithAuth.js to display specific error messages from backend responses when available, falling back to a generic session expired message if not. This improves user feedback for authentication errors.